### PR TITLE
feat: enhance Merge Request handling with commit range support

### DIFF
--- a/src/ai/prompt/summary_merge_request.md
+++ b/src/ai/prompt/summary_merge_request.md
@@ -26,9 +26,9 @@
   - 如果不适合使用图表，则忽略本章节，不强制使用图表。
   - 如果决定使用图表，选择最合适的Mermaid图表类型，如流程图、序列图、类图、状态图、实体关系图、用户旅程、甘特图、饼图、象限图、需求图、Git图（Gitgraph）、C4图、思维导图、时间线、Zenuml、桑基图、XY图、块图等。
   - 使用Mermaid语法编写图表代码，确保语法正确。将图表代码放在和之间。
-    - 在遵循 Mermaid 语法的基础上，注意用 " 包裹内容，以避免解析失败，以下是范例
-    **BAD CASE:** `F --> G[中文 fetchCategoryList(FilterTree)];`
-    **GOOD CASE:** `F --> G["中文 fetchCategoryList(FilterTree)"];`
+    - 在遵循 Mermaid 语法的基础上，注意用 " 包裹内容，以避免解析失败
+      - **BAD CASE:** `F --> G[中文 fetchCategoryList(FilterTree)];`
+      - **GOOD CASE:** `F --> G["中文 fetchCategoryList(FilterTree)"];`
   - 在图表前后提供文字解释，说明图表的内容和关键点。
   - 如果问题复杂，使用多个图表来解释不同方面。
   - 确保图表清晰简洁，避免过度复杂或信息过载。

--- a/src/gitlab/comment.py
+++ b/src/gitlab/comment.py
@@ -22,6 +22,26 @@ def create_comment(project_id: str, mr_number: str, content: str):
     return response.json()
 
 
+def get_comment(project_id: str, mr_number: str, sort="desc", order_by="created_at"):
+    """
+    ref: https://docs.gitlab.com/api/notes/#list-merge-request-notes
+
+    获取 Merge Request 的评论
+
+    Args:
+        project_id: The ID of the project
+        mr_number: The number of the merge request
+        sort: Return merge request notes sorted in asc or desc order. Default is desc
+        order_by: Return merge request notes ordered by created_at or updated_at fields. Default is created_at
+    """
+    url = f"{base_url}/projects/{project_id}/merge_requests/{mr_number}/notes"
+    response = requests.get(
+        url, headers=headers, params={"sort": sort, "order_by": order_by}
+    )
+    response.raise_for_status()
+    return response.json()
+
+
 # todo 为 Merge Request 创建 Thread 讨论
 def create_thread(project_id: str, mr_number: str, content: str):
     """
@@ -34,10 +54,7 @@ def create_thread(project_id: str, mr_number: str, content: str):
 
 if __name__ == "__main__":
     project_id, mr_number = parse_merge_request_url(
-        "https://git.intra.gaoding.com/npm/gdicon-cli/-/merge_requests/7"
+        "https://git.intra.gaoding.com/gdesign/meta/-/merge_requests/11124"
     )
-    create_comment(
-        project_id,
-        mr_number,
-        content="test",
-    )
+    result = get_comment(project_id, mr_number)
+    print(result[4]["body"])

--- a/src/gitlab/merge_request.py
+++ b/src/gitlab/merge_request.py
@@ -72,7 +72,6 @@ def get_merge_request_commits(
     project_id: str,
     mr_number: str,
     start_commit_hash: str = None,
-    end_commit_hash: str = None,
 ) -> list[Commit]:
     """
     获取 MR 提交记录
@@ -80,12 +79,11 @@ def get_merge_request_commits(
     Args:
         project_id: 项目 ID
         mr_number: MR 编号
-        start_commit_hash: 可选，起始 commit hash (包含)
-        end_commit_hash: 可选，结束 commit hash (包含)
+        start_commit_hash: 可选，起始 commit hash (包含)，返回从该 commit 开始到最新的所有 commits
 
     Returns:
-        list[Commit]: 如果指定了 start_commit_hash 和 end_commit_hash，
-                     则返回这个区间内的 commits（包含起始和结束）
+        list[Commit]: 如果指定了 start_commit_hash，则返回从该 commit 开始到最新的所有 commits；
+                     否则返回所有 commits
 
     https://docs.gitlab.com/api/merge_requests/#get-single-merge-request-commits
     """
@@ -93,13 +91,12 @@ def get_merge_request_commits(
     response = requests.get(url, headers=headers)
     all_commits = response.json()
 
-    # 如果没有指定区间参数，返回所有 commits
-    if not start_commit_hash or not end_commit_hash:
+    # 如果没有指定起始 commit，返回所有 commits
+    if not start_commit_hash:
         return all_commits
 
-    # 查找起始和结束 commit 的索引
+    # 查找起始 commit 的索引
     start_index = None
-    end_index = None
 
     for i, commit in enumerate(all_commits):
         # 匹配 commit hash (支持完整 hash 和 short hash)
@@ -109,25 +106,16 @@ def get_merge_request_commits(
             or commit["id"].startswith(start_commit_hash)
         ):
             start_index = i
-
-        if (
-            commit["id"] == end_commit_hash
-            or commit["short_id"] == end_commit_hash
-            or commit["id"].startswith(end_commit_hash)
-        ):
-            end_index = i
+            break
 
     # 如果找不到指定的 commit，返回所有 commits
-    if start_index is None or end_index is None:
+    if start_index is None:
         return all_commits
 
-    # 确保索引顺序正确（GitLab API 返回的 commits 是倒序的，最新的在前面）
-    # 所以我们需要取 min(start_index, end_index) 到 max(start_index, end_index)
-    min_index = min(start_index, end_index)
-    max_index = max(start_index, end_index)
-
-    # 返回指定区间内的 commits（包含起始和结束）
-    return all_commits[min_index : max_index + 1]
+    # 返回从指定 commit 开始到最新的所有 commits（包含起始 commit）
+    # GitLab API 返回的 commits 是倒序的，最新的在前面
+    # 所以从索引 0 到 start_index（包含）就是从最新到起始 commit
+    return all_commits[0 : start_index + 1]
 
 
 def get_compare_diff_from_commits(

--- a/src/workflow/summary_merge_request.py
+++ b/src/workflow/summary_merge_request.py
@@ -82,20 +82,23 @@ class SummaryMergeRequest(AsyncNode):
             commits = get_merge_request_commits(
                 project_id, merge_number, end_commit_hash
             )
-            # 移除最后一个 commit（已经总结过了）
-            commits = commits[:-1]
+
             # 获取区间 diff
             actual_start = commits[-1]["short_id"] if commits else start_commit_hash
             actual_end = commits[0]["short_id"] if commits else end_commit_hash
             raw_diff = get_compare_diff_from_commits(
                 project_id, actual_start, actual_end
             )
+
+            # 移除最后一个 commit（已经总结过了）
+            commits = commits[:-1]
         else:
             # 获取整个 MR 的所有内容（完整模式）
-            commits = get_merge_request_commits(project_id, merge_number)
             raw_diff = get_merge_request_raw_diff(project_id, merge_number)
             actual_start = commits[-1]["short_id"]
             actual_end = commits[0]["short_id"]
+
+            commits = get_merge_request_commits(project_id, merge_number)
 
         # 设置共享数据
         shared.update(


### PR DESCRIPTION
- Added `get_comment` function to retrieve comments from Merge Requests.
- Updated `get_merge_request_commits` to support fetching commits within a specified range.
- Modified `SummaryMergeRequest` to utilize start and end commit hashes from comments for diff and commit retrieval.
- Improved handling of raw diffs and commit information based on the presence of commit hashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve and display comments from a GitLab merge request.
  * Enhanced commit retrieval to allow filtering commits starting from a specified commit hash.
  * Summaries now track and display the specific commit range summarized, using commit hashes embedded in comments.

* **Documentation**
  * Reformatted and clarified instructions for using Mermaid syntax in diagrams, improving readability with nested bullet points and clearer examples.

* **Refactor**
  * Improved workflow for summarizing merge requests by only summarizing new commits since the last summary, based on commit hashes found in comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->